### PR TITLE
Don't mutate the path argument

### DIFF
--- a/lib/deep-property-access.js
+++ b/lib/deep-property-access.js
@@ -13,6 +13,7 @@ var DeepPropertyAccess = function(base, path) {
   if (path.length > 0) {
     var validPath = true;
     var retval = base;
+    path = path.slice()
     while (path.length > 0) {
       retval = retval[path.shift()];
       if (typeof retval === 'undefined') {


### PR DESCRIPTION
Unless I misunderstood, this seems like it would destroy the path array that someone passes in (which is fine for single-use literals, but what if it's a variable I wanted to use a couple times?)

So I made it not mutate the inputs by adding path.slice() to create a copy of the array that path.shift() can then destroy